### PR TITLE
Enable spoof_build_vars on initial install to pass by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ format:
 
 > **Zygisk (or Zygisk Next) is needed for this feature to work.**
 
-If you still do not pass you can try enabling Build variable spoofing by creating the file `/data/adb/tricky_store/spoof_build_vars`.
+If you still do not pass you can try enabling/disabling Build variable spoofing by creating/deleting the file `/data/adb/tricky_store/spoof_build_vars`.
 
-Tricky Store will automatically generate example config props inside `/data/adb/tricky_store/spoof_build_vars` on next reboot, then you can manually edit your spoof config.
+Tricky Store will automatically generate example config props inside `/data/adb/tricky_store/spoof_build_vars` once created, on next reboot, then you may manually edit your spoof config.
 
-Here is an example of spoof config:
+Here is an example of a spoof config:
 
 ```
 MANUFACTURER=Google

--- a/README.md
+++ b/README.md
@@ -50,17 +50,17 @@ Here is an example of a spoof config:
 
 ```
 MANUFACTURER=Google
-MODEL=Pixel
-FINGERPRINT=google/sailfish/sailfish:8.1.0/OPM1.171019.011/4448085:user/release-keys
+MODEL=Pixel 8 Pro
+FINGERPRINT=google/husky_beta/husky:15/AP31.240617.009/12094726:user/release-keys
 BRAND=google
-PRODUCT=sailfish
-DEVICE=sailfish
-RELEASE=8.1.0
-ID=OPM1.171019.011
-INCREMENTAL=4448085
+PRODUCT=husky_beta
+DEVICE=husky
+RELEASE=15
+ID=AP31.240617.009
+INCREMENTAL=12094726
 TYPE=user
 TAGS=release-keys
-SECURITY_PATCH=2017-12-05
+SECURITY_PATCH=2024-07-05
 ```
 
 ## Support TEE broken devices

--- a/module/src/main/cpp/zygisk/main.cpp
+++ b/module/src/main/cpp/zygisk/main.cpp
@@ -257,16 +257,16 @@ static void companion_handler(int fd) {
     constexpr auto kDefaultSpoofConfig =
 R"EOF(MANUFACTURER=Google
 MODEL=Pixel
-FINGERPRINT=google/sailfish/sailfish:8.1.0/OPM1.171019.011/4448085:user/release-keys
+FINGERPRINT=google/sailfish/sailfish:10/QPP3.190404.015/5505587:user/release-keys
 BRAND=google
 PRODUCT=sailfish
 DEVICE=sailfish
-RELEASE=8.1.0
-ID=OPM1.171019.011
-INCREMENTAL=4448085
+RELEASE=10
+ID=QPP3.190404.015
+INCREMENTAL=5505587
 TYPE=user
 TAGS=release-keys
-SECURITY_PATCH=2017-12-05
+SECURITY_PATCH=2019-05-05
 )EOF"sv;
     struct stat st{};
     int enabled = stat(kSpoofConfigFile.data(), &st) == 0;

--- a/module/template/customize.sh
+++ b/module/template/customize.sh
@@ -93,6 +93,7 @@ CONFIG_DIR=/data/adb/tricky_store
 if [ ! -d "$CONFIG_DIR" ]; then
   ui_print "- Creating configuration directory"
   mkdir -p "$CONFIG_DIR"
+  [ ! -f "$CONFIG_DIR/spoof_build_vars" ] && touch "$CONFIG_DIR/spoof_build_vars"
 fi
 if [ ! -f "$CONFIG_DIR/keybox.xml" ]; then
   ui_print "- Adding default software keybox"


### PR DESCRIPTION
- most devices seem to require spoof_build_vars so enable it by default, but only on new installs, so that they pass MEETS_DEVICE_INTEGRITY out of the box
- this still allows it to be disabled by simply deleting the file after initial install for those who want to avoid Zygisk usage and/or can pass with their own device values
- some fingerprints which pass STRONG with hardware keybox do not seem to also pass DEVICE with the AOSP software keybox, but many do both, so switch to one
- update example fingerprint to be a helpful hint for users looking for ones that work going forward