### PR TITLE
fix wrong module name in `customize.sh`

### DIFF
--- a/module/build.gradle.kts
+++ b/module/build.gradle.kts
@@ -111,7 +111,8 @@ afterEvaluate {
                     "DEBUG" to if (buildTypeLowered == "debug") "true" else "false",
                     "SONAME" to moduleId,
                     "SUPPORTED_ABIS" to supportedAbis,
-                    "MIN_SDK" to androidMinSdkVersion.toString()
+                    "MIN_SDK" to androidMinSdkVersion.toString(),
+                    "MODULENAME" to moduleName
                 )
                 filter<ReplaceTokens>("tokens" to tokens)
                 filter<FixCrLfFilter>("eol" to FixCrLfFilter.CrLf.newInstance("lf"))

--- a/module/template/customize.sh
+++ b/module/template/customize.sh
@@ -12,7 +12,7 @@ if [ "$BOOTMODE" ] && [ "$KSU" ]; then
   if [ "$(which magisk)" ]; then
     ui_print "*********************************************************"
     ui_print "! Multiple root implementation is NOT supported!"
-    ui_print "! Please uninstall Magisk before installing Zygisk Next"
+    ui_print "! Please uninstall Magisk before installing @MODULENAME@"
     abort    "*********************************************************"
   fi
 elif [ "$BOOTMODE" ] && [ "$MAGISK_VER_CODE" ]; then


### PR DESCRIPTION
In module install script `customize.sh`, change `Zygisk Next` to `Tricky Store` in error message.