### PR TITLE
Optimize BinderInterceptor.kt

### DIFF
--- a/service/src/main/java/io/github/a13e300/tricky_store/binder/BinderInterceptor.kt
+++ b/service/src/main/java/io/github/a13e300/tricky_store/binder/BinderInterceptor.kt
@@ -53,9 +53,11 @@ open class BinderInterceptor : Binder() {
                 val callingUid = data.readInt()
                 val callingPid = data.readInt()
                 val sz = data.readLong()
+                val buffer = ByteArray(sz.toInt())
+                data.readByteArray(buffer)
                 val theData = Parcel.obtain()
                 try {
-                    theData.appendFrom(data, data.dataPosition(), sz.toInt())
+                    theData.unmarshall(buffer, 0, buffer.size)
                     theData.setDataPosition(0)
                     onPreTransact(target, theCode, theFlags, callingUid, callingPid, theData)
                 } finally {


### PR DESCRIPTION
Use a temporary buffer to avoid creating a new Parcel. In theory, optimize ram usage